### PR TITLE
rollupOptions.input is an absolute path

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ class GulpRollup extends Transform {
 		// user should not specify the input file path, but let him if he insists for some reason
 		if (rollupOptions.input === undefined)
 			// determine input from file filename
-			rollupOptions.input = path.relative(file.cwd, file.path)
+			rollupOptions.input = path.resolve(file.cwd, file.path)
 		else
 			// rename file if input is given
 			file.path = path.join(file.cwd, rollupOptions.input)

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "gulp-util": "^3.0.8",
     "lodash.camelcase": "^4.3.0",
-    "rollup": "^0.50.0",
+    "rollup": "^0.53.3",
     "vinyl-sourcemaps-apply": "^0.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This fixes an use case when a gulp task operate on a folder/file outside of current working directory.