### PR TITLE
remove gulp-util dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,8 @@
 'use strict'
 
 var Transform = require('stream').Transform
-var gutil = require('gulp-util')
-var File = gutil.File
-var PluginError = gutil.PluginError
+var File = require('vinyl')
+var PluginError = require('plugin-error')
 var rollup = require('rollup')
 var path = require('path')
 var applySourceMap = require('vinyl-sourcemaps-apply')

--- a/package.json
+++ b/package.json
@@ -23,9 +23,10 @@
     "es6"
   ],
   "dependencies": {
-    "gulp-util": "^3.0.8",
     "lodash.camelcase": "^4.3.0",
+    "plugin-error": "^0.1.2",
     "rollup": "^0.50.0",
+    "vinyl": "^2.1.0",
     "vinyl-sourcemaps-apply": "^0.2.1"
   },
   "devDependencies": {

--- a/test/test.js
+++ b/test/test.js
@@ -2,7 +2,7 @@
 
 var path = require('path')
 var should = require('should')
-var File = require('gulp-util').File
+var File = require('vinyl')
 var sourceMaps = require('gulp-sourcemaps')
 var rollup = require('..')
 


### PR DESCRIPTION
Hi there

The gulp-util package is being deprecated, for more information see: https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5.

This pull request removes the dependency on gulp-util and replaces it with the recommended libraries.