### PR TITLE
Updated rollup to version 0.56

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "lodash.camelcase": "^4.3.0",
     "plugin-error": "^0.1.2",
-    "rollup": "^0.50.0",
+    "rollup": ">=0.48 <0.57",
     "vinyl": "^2.1.0",
     "vinyl-sourcemaps-apply": "^0.2.1"
   },

--- a/test/test.js
+++ b/test/test.js
@@ -142,13 +142,7 @@ describe('gulp-better-rollup', function() {
 
 	it('should create a bundle with globals from cache', done => {
 		var stream = rollup({
-			onwarn: ({code, message}) => {
-				if (code === 'UNRESOLVED_IMPORT') {
-					return;
-				}
-
-				console.warn(message);
-			}
+			external: ['jquery']
 		}, {
 			format: 'iife',
 			globals: {


### PR DESCRIPTION
I've set the Rollup version to the range `[0.48–0.57)`. As I can see in the [Rollup change log](https://github.com/rollup/rollup/blob/master/CHANGELOG.md) this versions are backward compatible. So the major version of `gulp-better-rollup` should not be bumped, I think `3.1.0` is ok.

Could you please publish it?