### PR TITLE
Docs improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/MikeKovarik/gulp-better-rollup.svg?branch=master)](https://travis-ci.org/MikeKovarik/gulp-better-rollup)
 
-A [Gulp](https://www.npmjs.com/package/gulp) plugin for [Rollup](https://www.npmjs.com/package/rollup) ES6 Bundler. This plugin unlike [gulp-rollup](https://www.npmjs.com/package/gulp-rollup) integrates Rollup deeper into Gulps pipeline chain by taking some of the Rollup API out of your hands in exchange of giving you the full power over the pipeline (to use any gulp plugins).
+A [Gulp](https://www.npmjs.com/package/gulp) plugin for [Rollup](https://www.npmjs.com/package/rollup) ES6 Bundler. In comparison with [gulp-rollup](https://www.npmjs.com/package/gulp-rollup), this plugin integrates Rollup deeper into Gulps pipeline chain. It takes some of the Rollup API out of your hands, in exchange for giving you full power over the pipeline (to use any gulp plugins).
 
 ## Installation
 
@@ -40,7 +40,7 @@ or simply
 gulp.task('lib-build', () => {
   gulp.src('lib/mylibrary.js')
     .pipe(sourcemaps.init())
-    // note that UMD and IIFE format requires `name` but it was guessed based on source file `mylibrary.js`
+    // note that UMD and IIFE format requires `name` but it will be inferred from the source file name `mylibrary.js`
     .pipe(rollup({plugins: [babel()]}, 'umd'))
     // save sourcemap as separate file (in the same folder)
     .pipe(sourcemaps.write(''))
@@ -52,12 +52,12 @@ gulp.task('lib-build', () => {
 
 ### `rollup([rollupOptions,] generateOptions)`
 
-This plugin is based on [the standard Rollup options](https://github.com/rollup/rollup/wiki/JavaScript-API), with following caveats
+This plugin is based on [the standard Rollup options](https://github.com/rollup/rollup/wiki/JavaScript-API), with the following exceptions:
 
 #### `rollupOptions`
-First argument is object of options found you would specify as [`rollup.rollup(options)` in Rollup API](https://github.com/rollup/rollup/wiki/JavaScript-API#rolluprollup-options-)
+See [`rollup.rollup(options)` in the Rollup API](https://github.com/rollup/rollup/wiki/JavaScript-API#rolluprollup-options-)
 
-`input` should not be used as the entry file is provided by gulp. It also works with gulp-watch
+`input` is unsupported, as the entry file is provided by gulp, which also works with [gulp-watch](https://www.npmjs.com/package/gulp-watch).
 
 ``` js
   gulp.src('src/app.js')
@@ -66,7 +66,7 @@ First argument is object of options found you would specify as [`rollup.rollup(o
     .pipe(gulp.dest('./dist'))
 ```
 
-But if you really need it for some bizzare reason then you can specify custom entry like so
+If you still need it for some reason, then you can specify a custom entry:
 
 ``` js
   gulp.src('src/app.js')
@@ -77,27 +77,25 @@ But if you really need it for some bizzare reason then you can specify custom en
     .pipe(gulp.dest('./dist'))
 ```
 
-`cache` is enabled by default and taken care of by the plugin because usage in cojunction with watchers like [gulp-watch](https://www.npmjs.com/package/gulp-watch) is expected. It can be however disabled by settings `cache` to `false`
+`cache` is enabled by default and taken care of by the plugin, because usage in conjunction with watchers like [gulp-watch](https://www.npmjs.com/package/gulp-watch) is expected. It can however be disabled by settings `cache` to `false`.
 
 #### `generateOptions`
 
-Second argument is object of options describing output format of the bundle. It's the same thing you would specify as [`bundle.generate(options)` in Rollup API](https://github.com/rollup/rollup/wiki/JavaScript-API#bundlegenerate-options-) or as a single item of  `targets` in `rollup.config.js`
+Options describing the output format of the bundle. See [`bundle.generate(options)` in the Rollup API](https://github.com/rollup/rollup/wiki/JavaScript-API#bundlegenerate-options-).
 
-`name` and `amd.id` are by default assigned by filename but can be explicitly specified
+`name` and `amd.id` are inferred from the module file name by default, but can be explicitly specified to override this. For example, if your main file is named `index.js` or `main.js`, then your module would also be named `index` or `main`, which you may not want.
 
-**Caveat:** Exporting to UMD or IIFE format requires to specify `name`. This plugin takes care of autoassigning it based on filename. But if your main file is named `index.js` or `main.js` then your module will be also named `index` or `main`.
+To use [unnamed modules](http://requirejs.org/docs/api.html#modulename) for amd, set `amd.id` to an empty string, ex: `.pipe(rollup({amd:{id:''}}))`.
 
-**Caveat:** If you don't want `amd.id` to be automatically assigned for your AMD modules, set `amd.id` to empty string `.pipe(rollup({amd:{id:''}}))`
+`intro/outro` is supported, but we encouraged you to use gulps standard plugins like [gulp-header](https://www.npmjs.com/package/gulp-header) and [gulp-footer](https://www.npmjs.com/package/gulp-footer).
 
-`intro/outro` are discouraged to use in favor of gulps standard plugins like [gulp-header](https://www.npmjs.com/package/gulp-header) and [gulp-footer](https://www.npmjs.com/package/gulp-footer)
-
-`sourcemap` option is omitted. Use the standard [gulp-sourcemaps](https://www.npmjs.com/package/gulp-sourcemaps) plugin instead.
-
-`sourcemapFile` is unvailable as well.
+`sourcemap` and `sourcemapFile` are unsupported. Use the standard [gulp-sourcemaps](https://www.npmjs.com/package/gulp-sourcemaps) plugin instead.
 
 #### shortcuts
 
-If you don't need to define `plugins` like babel, use `external` modules, explicitly specify `input` file, or any other options of `rollupOptions` object, you can just skip this first argument alltogether. Also `generateOptions` can be replaced by string of module format if you only export in a single format.
+You can skip this first argument if you don't need to specify `rollupOptions`.
+
+`generateOptions` accepts a string with the module format, in case you only want to support a single format.
 
 ``` js
 gulp.task('dev', function() {
@@ -107,7 +105,7 @@ gulp.task('dev', function() {
 })
 ```
 
-**Both `rollupOptions` and `generateOptions` can be also specified as a single object** if you preffer simplicity over semantically relying on the Rollup JS API. This could also come in handy as setting defaults for `generateOptions` when you export multiple formats and you don't want to copy-paste the same `exports` and `blobal` options.
+**`rollupOptions` and `generateOptions` can be also be specified as a shared object** if you prefer simplicity over adherence to the Rollup JS API semantics.
 
 ``` js
 gulp.task('dev', function() {
@@ -124,7 +122,7 @@ gulp.task('dev', function() {
 })
 ```
 
-Can be simplified into
+Can be simplified into:
 
 ``` js
 gulp.task('dev', function() {
@@ -142,7 +140,7 @@ gulp.task('dev', function() {
 
 #### exporting multiple bundles
 
-Array of `generateOptions` can be provided to export into multiple formats.
+`generateOptions` can be an array, in order to export to multiple formats.
 
 ```js
 var pkg = require('./package.json')
@@ -161,7 +159,6 @@ gulp.task('build', function() {
 })
 ```
 
-**Caveat 1:** `file` can take path instead of just a file name, but the file won't be saved there. Exporting files from gulp always relies on the `.pipe(gulp.dest(...))` and not the plugin itself.
+**Caveat 1:** `file` can take the file path instead of just a file name, but the file won't be saved there. Exporting files from gulp always relies on the `.pipe(gulp.dest(...))`, not the plugin itself.
 
-**Caveat 2:** `gulp-sourcemaps` plugin doesn't (yet) support the `.mjs` extension you might want to use to export ES format into. Specifically it can inline the sourcemap into the bundle file (using `sourcemaps.write()`), and it can also create external sourcemap file with `sourcemaps.write(PATH_TO_SOURCEMAP_FOLDER)`, it just won't insert the `//# sourceMappingURL=` linking comment at the end of your `.mjs` file, effectivelly rendering the sourcemap useless. 
-
+**Caveat 2:** The `gulp-sourcemaps` plugin doesn't (yet) support the `.mjs` extension, that you may want to use to support the ES module format in Node.js. It can inline the sourcemap into the bundle file (using `sourcemaps.write()`), and create an external sourcemap file with `sourcemaps.write(PATH_TO_SOURCEMAP_FOLDER)`. It won't however insert the `//# sourceMappingURL=` linking comment at the end of your `.mjs` file, which effectively renders the sourcemaps useless. 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ gulp.task('dev', function() {
 })
 ```
 
-**`rollupOptions` and `generateOptions` can be also be specified as a shared object** if you prefer simplicity over adherence to the Rollup JS API semantics.
+**`rollupOptions` and `generateOptions` can also be specified as a shared object** if you prefer simplicity over adherence to the Rollup JS API semantics.
 
 ``` js
 gulp.task('dev', function() {


### PR DESCRIPTION
Rewrote much of the documentation to fix typos, punctuation, grammar and simplifying the "flow" by avoiding long sentences or repetition.

Hopefully I didn't step on your toes by taking liberties.

Some changes are more controversial and may need to be motivated further:

* The automatic module name inference is explained repeated times in the same section. I think it only needs to be explained once. Rewriting that section I also removed the "caveats". "Caveat" have negative connotations, like "red flag", or quirky exception you have to handle. I also explained what naming amd.id to an empty string actually does and linked to the require.js documentation, since most people probably don't know what named amd modules are or want them.

* Removed or replaced suggestions and value judgment in order to make the readme more neutral and "to the point". Examples: "for some bizarre reason", "should not be used" (replaced with "unsupported") and "This could also come in handy as setting defaults for generateOptions when you export multiple formats and you don't want to copy-paste the same exports and global options".

* Tried to use the same (value neutral) terminology repeatedly. Ex "supported"/"unsupported" and "inferred" were described using varying terms and expressions before.

What I didn't do:
* Update outdated links (to rollup). The current links are outdated. They lead to a redirection to the new documentation, but the anchor (`#`) is lost.
* I don't actually understand the meaning of "but the file won't be saved there" (second last paragraph). Does it strip the path name and only use the file name part of it? This can be probably be made clearer.