### PR TITLE
Simplify cache process. Fixes #42

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ try {
 }
 
 // map object storing rollup cache objects for each input file
-var rollupCache = null
+var rollupCache = {}
 
 function parseBundles(arg) {
 	if (typeof arg == 'string')
@@ -64,9 +64,8 @@ class GulpRollup extends Transform {
 
 		// caching is enabled by default because of the nature of gulp and the watching/recompilatin
 		// but can be disabled by setting 'cache' to false
-		if (inputOptions.cache !== false) {
-			inputOptions.cache = rollupCache
-		}
+		if (inputOptions.cache !== false)
+			inputOptions.cache = rollupCache[inputOptions.input] || null
 
 		// enable sourcemap is gulp-sourcemaps plugin is enabled
 		var createSourceMap = file.sourceMap !== undefined
@@ -163,7 +162,7 @@ class GulpRollup extends Transform {
 			.then(bundle => {
 				// cache rollup object if caching is enabled
 				if (inputOptions.cache !== false)
-					rollupCache = bundle
+					rollupCache[inputOptions.input] = bundle
 				// generate ouput according to (each of) given outputOptions
 				return Promise.all(bundleList.map((outputOptions, i) => createBundle(bundle, outputOptions, i)))
 			})
@@ -171,7 +170,7 @@ class GulpRollup extends Transform {
 			.then(() => cb(null, file))
 			.catch(err => {
 				if (inputOptions.cache !== false)
-					rollupCache = null
+					rollupCache[inputOptions.input] = null
 				process.nextTick(() => {
 					this.emit('error', new PluginError(PLUGIN_NAME, err))
 					cb(null, file)

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ try {
 }
 
 // map object storing rollup cache objects for each input file
-var rollupCache = new Map
+var rollupCache = null
 
 function parseBundles(arg) {
 	if (typeof arg == 'string')
@@ -64,8 +64,9 @@ class GulpRollup extends Transform {
 
 		// caching is enabled by default because of the nature of gulp and the watching/recompilatin
 		// but can be disabled by setting 'cache' to false
-		if (inputOptions.cache !== false)
-			inputOptions.cache = rollupCache.get(inputOptions.input)
+		if (inputOptions.cache !== false) {
+			inputOptions.cache = rollupCache
+		}
 
 		// enable sourcemap is gulp-sourcemaps plugin is enabled
 		var createSourceMap = file.sourceMap !== undefined
@@ -162,7 +163,7 @@ class GulpRollup extends Transform {
 			.then(bundle => {
 				// cache rollup object if caching is enabled
 				if (inputOptions.cache !== false)
-					rollupCache.set(inputOptions.input, bundle)
+					rollupCache = bundle
 				// generate ouput according to (each of) given outputOptions
 				return Promise.all(bundleList.map((outputOptions, i) => createBundle(bundle, outputOptions, i)))
 			})
@@ -170,7 +171,7 @@ class GulpRollup extends Transform {
 			.then(() => cb(null, file))
 			.catch(err => {
 				if (inputOptions.cache !== false)
-					rollupCache.delete(inputOptions.input)
+					rollupCache = null
 				process.nextTick(() => {
 					this.emit('error', new PluginError(PLUGIN_NAME, err))
 					cb(null, file)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-better-rollup",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Better Gulp plugin for Rollup ES6 module bundler",
   "author": "Mike Kovarik",
   "license": "MIT",


### PR DESCRIPTION
I'm not sure how to write a test for this, but when using Map() for the cache, rollup eventually develops a memory leak and crashes. For me, it happens after 7 runs with gulp-watch.

This is obviously a problem with the Map implementation, but using a plain JavaScript object for the cache addresses the symptoms of the issue for me.