### PR TITLE
peerDependencies - "rollup": "^1.4.1||^2.0.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "vinyl-sourcemaps-apply": "^0.2.1"
   },
   "peerDependencies": {
-    "rollup": "^1.4.1"
+    "rollup": "^1.4.1||^2.0.0"
   },
   "devDependencies": {
     "gulp-sourcemaps": "^2.1.1",


### PR DESCRIPTION
I'm using rollup@2 with this lib for a while now and it works great.
With npm@7 I can't run `npm update` anymore because it violates this peerDependencies rule.